### PR TITLE
fix handling of json log messages

### DIFF
--- a/dock/util.py
+++ b/dock/util.py
@@ -97,9 +97,15 @@ def wait_for_command(logs_generator):
             try:
                 parsed_item = json.loads(item)
             except ValueError:
-                line = item
-            else:
+                pass
+
+            # make sure the json is an object
+            if isinstance(parsed_item, dict):
                 line = parsed_item.get("stream", "")
+            else:
+                parsed_item = None
+                line = item
+
             line = line.replace("\r\n", " ").replace("\n", " ").strip()
             if line:
                 logger.debug(line)


### PR DESCRIPTION
wait_for_command tries to parse each line as a json. If the line was a
valid json that is not an object (e.g. "string") the code raised an
exception.