### PR TITLE
indicate that the build failed

### DIFF
--- a/dock/cli/main.py
+++ b/dock/cli/main.py
@@ -56,6 +56,9 @@ def cli_build_image(args):
             response.return_code = -1
         else:
             response.return_code = 0
+
+    if response.return_code != 0:
+        logger.error("build failed")
     sys.exit(response.return_code)
 
 


### PR DESCRIPTION
So that non-verbose logs for successful and failed build don't look exactly the same.