### PR TITLE
added template input plugin

### DIFF
--- a/dock/plugins/input_template.py
+++ b/dock/plugins/input_template.py
@@ -1,7 +1,7 @@
 """
 Reads the template from template paths and replace stuff in it
 Usage:
-dock --input template --input-arg template_path=/tmp/template.json --input-arg replace=key1=value1,key2=value2,key3=value3
+dock --input template --input-arg template_path=/tmp/template.json --input-arg key1=value1 --input-arg key2=value2 
 
 """
 import json
@@ -21,14 +21,14 @@ def replace_dict(adict, rkey, rvalue):
 class TemplateInputPlugin(InputPlugin):
     key = "template"
 
-    def __init__(self, template_path=None, replace=None):
+    def __init__(self, template_path=None, **kwargs):
         """
         constructor
         """
         # call parent constructor
         super(TemplateInputPlugin, self).__init__()
         self.template_path = template_path
-        self.replace = replace
+        self.kwargs = kwargs
 
     def run(self):
         """
@@ -44,8 +44,7 @@ class TemplateInputPlugin(InputPlugin):
             self.log.error("couldn't read json from file '%s'", self.template_path)
             return None
         else:
-            for change in self.replace.split(','):
-                key, value = change.split('=')
+            for key, value in self.kwargs.iteritems():
                 replace_dict(build_cfg_json, key, value)
             self.log.debug(build_cfg_json)
             return build_cfg_json

--- a/dock/plugins/input_template.py
+++ b/dock/plugins/input_template.py
@@ -1,0 +1,51 @@
+"""
+Reads the template from template paths and replace stuff in it
+Usage:
+dock --input template --input-arg template_path=/tmp/template.json --input-arg replace=key1=value1,key2=value2,key3=value3
+
+"""
+import json
+
+from dock.plugin import InputPlugin
+
+def replace_dict(adict, rkey, rvalue):
+    for key in adict.keys():
+        if adict[key] == rkey:
+            adict[key] = rvalue
+        elif type(adict[key]) is dict:
+            replace_dict(adict[key], rkey, rvalue)
+        elif type(adict[key]) is list:
+            for i in range(len(adict[key])):
+                replace_dict(adict[key][i], rkey, rvalue)
+
+class TemplateInputPlugin(InputPlugin):
+    key = "template"
+
+    def __init__(self, template_path=None, replace=None):
+        """
+        constructor
+        """
+        # call parent constructor
+        super(TemplateInputPlugin, self).__init__()
+        self.template_path = template_path
+        self.replace = replace
+
+    def run(self):
+        """
+        open json template and replace stuff in it
+        """
+        try:
+            with open(self.template_path, 'r') as build_cfg_fd:
+                build_cfg_json = json.load(build_cfg_fd)
+        except ValueError:
+            self.log.error("couldn't decode json from file '%s'", self.template_path)
+            return None
+        except IOError:
+            self.log.error("couldn't read json from file '%s'", self.template_path)
+            return None
+        else:
+            for change in self.replace.split(','):
+                key, value = change.split('=')
+                replace_dict(build_cfg_json, key, value)
+            self.log.debug(build_cfg_json)
+            return build_cfg_json


### PR DESCRIPTION
Implemented input template plugin. It can be run like: 
```
dock --input template --input-arg template_path=/tmp/template.json --input-arg replace=IMGNAME=jboss-docker-base,TESTS=node
```
then following json:
``` json
{
  "git_url": "http://git.app.eng.bos.redhat.com/git/jboss-dockerfiles.git",
  "git_commit": "master",
  "git_dockerfile_path": "standalone/eap/6.4",
  "image": "IMGNAME",
  "prepublish_plugins": [{
    "name": "test_built_image",
    "args": {
      "image_id": "BUILT_IMAGE_ID",
      "git_uri": "https://github.com/jboss-dockerfiles/tools",
      "git_commit": "master",
      "tests_git_path": "test/docker_test_base.py",
      "tests": "TESTS"
    }
  }]
}
```
will be translated to 
``` json
{
  "git_url": "http://git.app.eng.bos.redhat.com/git/jboss-dockerfiles.git",
  "git_commit": "master",
  "git_dockerfile_path": "standalone/eap/6.4",
  "image": "jboss-docker-base",
  "prepublish_plugins": [{
    "name": "test_built_image",
    "args": {
      "image_id": "BUILT_IMAGE_ID",
      "git_uri": "https://github.com/jboss-dockerfiles/tools",
      "git_commit": "master",
      "tests_git_path": "test/docker_test_base.py",
      "tests": "none"
    }
  }]
}
```
