### PR TITLE
Avoid traceback when handling dict values that are dicts.

### DIFF
--- a/dock/plugin.py
+++ b/dock/plugin.py
@@ -245,7 +245,7 @@ class BuildPluginsRunner(PluginsRunner):
         }
         translated_dict = copy.deepcopy(dict_to_translate)
         for key, value in dict_to_translate.items():
-            if value in translation_dict:
+            if (not (type(value) is dict)) and value in translation_dict:
                 translated_dict[key] = translation_dict[value]
         return translated_dict
 

--- a/dock/plugin.py
+++ b/dock/plugin.py
@@ -243,14 +243,14 @@ class BuildPluginsRunner(PluginsRunner):
             'BASE_IMAGE': join_img_name_tag(self.workflow.builder.base_image_name,
                                             self.workflow.builder.base_tag)
         }
-        if type(obj_to_translate) is dict:
+        if isinstance(obj_to_translate, dict):
             # Recurse into dicts
             translated_dict = copy.deepcopy(obj_to_translate)
             for key, value in obj_to_translate.items():
                 translated_dict[key] = self._translate_special_values (value)
 
             return translated_dict
-        elif type(obj_to_translate) is list:
+        elif isinstance(obj_to_translate, list):
             # Iterate over lists
             return [self._translate_special_values(elem)
                     for elem in obj_to_translate]


### PR DESCRIPTION
This happens with, for instance, this:

```
"args": {
  "labels": {
    "label1": "value1",
    "label2": "value2"
  }
}
```

The actual traceback looks like this:

```
Traceback (most recent call last):
  File "/usr/bin/dock", line 9, in <module>
    load_entry_point('dock==1.1.1', 'console_scripts', 'dock')()
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/cli/main.py", line 187, in run
    cli.run()
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/cli/main.py", line 170, in run
    args.func(args)
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/cli/main.py", line 66, in cli_inside_build
    build_inside(input=args.input, input_args=args.input_arg, substitutions=args.substitute)
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/inner.py", line 215, in build_inside
    image = dbw.build_docker_image()
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/inner.py", line 132, in build_docker_image
    prebuild_runner.run()
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/plugin.py", line 203, in run
    plugin_instance = self.create_instance_from_plugin(plugin_class, plugin_conf)
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/plugin.py", line 253, in create_instance_from_plugin
    translated_conf = self._translate_special_values(plugin_conf)
  File "/usr/lib/python2.7/site-packages/dock-1.1.1-py2.7.egg/dock/plugin.py", line 248, in _translate_special_values
    if value in translation_dict:
TypeError: unhashable type: 'dict'
```