### PR TITLE
Travis CI (#38)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.4"
+# command to install dependencies
+install:
+  - "pip install -r requirements.txt"
+  - "pip install -r tests/requirements.txt"
+# command to run tests
+script: py.test -v
+# run in a docker container
+sudo: false
+notifications:
+  email: false

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,16 @@
+Requirements: see requirements.txt
+
+How to run:
+$ py.test -v
+
+By default all docker.Client methods are mocked, so you don't need docker to run these tests.
+If you want to run 'integration' tests, i.e. test with running docker instance, you need:
+$ yum install docker docker-registry
+$ systemctl start docker docker-registry
+$ dock create-build-image --dock-local-path ${PATH_TO_DOCK_GIT} ${PATH_TO_DOCK_GIT}/images/dockerhost-builder buildroot
+$ docker tag buildroot:latest buildroot-dh-fedora
+$ docker tag buildroot:latest buildroot-fedora
+$ docker pull fedora:latest
+$ docker tag fedora:latest localhost:5000/fedora:latest
+$ docker push fedora:latest localhost:5000/fedora:latest
+$ NOMOCK=1 py.test -v

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,3 +1,5 @@
+import os
+MOCK = os.environ.get('NOMOCK') is None
 
 INPUT_IMAGE = "busybox:latest"
 DOCKERFILE_GIT = "https://github.com/TomasTomecek/docker-hello-world.git"
@@ -10,3 +12,5 @@ LOCALHOST_REGISTRY = "localhost:%s" % REGISTRY_PORT
 DOCKER0_REGISTRY = "%s:%s" % (DOCKER0_IP, REGISTRY_PORT)
 LOCALHOST_REGISTRY_HTTP = "http://%s" % LOCALHOST_REGISTRY
 DOCKER0_REGISTRY_HTTP = "http://%s" % DOCKER0_REGISTRY
+
+COMMAND = "eporeporjgpeorjgpeorjgpeorjgpeorjgpeorjg"

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -1,0 +1,76 @@
+import os
+import docker
+from flexmock import flexmock
+
+from tests.constants import COMMAND
+
+mock_containers = \
+    [{'Created': 1430292310,
+      'Image': 'fedora',
+      'Names': ['/goofy_mayer'],
+      'Command': '/bin/bash',
+      'Id': 'f8ee920b2db5e802da2583a13a4edbf0523ca5fff6b6d6454c1fd6db5f38014d',
+      'Status': 'Up 2 seconds'},
+     {'Created': 1430293290,
+      'Image': 'busybox:latest',
+      'Names': ['/boring_mestorf'],
+      'Id': '105026325ff668ccf4dc2bcf4f009ea35f2c6a933a778993e6fad3c50173aaab',
+      'Command': COMMAND}]
+
+mock_image = \
+    {'Created': 1414577076,
+     'Id': '3ab9a7ed8a169ab89b09fb3e12a14a390d3c662703b65b4541c0c7bde0ee97eb',
+     'ParentId': 'a79ad4dac406fcf85b9c7315fe08de5b620c1f7a12f45c8185c843f4b4a49c4e',
+     'RepoTags': ['buildroot-fedora:latest'],
+     'Size': 0,
+     'VirtualSize': 856564160}
+
+mock_logs = b'uid=0(root) gid=0(root) groups=10(wheel)'
+
+mock_build_logs = \
+    [b'{"stream":"Step 0 : FROM fedora:latest\\n"}\r\n',
+     b'{"status":"Pulling from fedora","id":"latest"}\r\n',
+     b'{"status":"Digest: sha256:c63476a082b960f6264e59ef0ff93a9169eac8daf59e24805e0382afdcc9082f"}\r\n',
+     b'{"status":"Status: Image is up to date for fedora:latest"}\r\n',
+     b'{"stream":"Step 1 : RUN uname -a \\u0026\\u0026 env\\n"}\r\n',
+     b'{"stream":" ---\\u003e Running in 3600c91d1c40\\n"}\r\n',
+     b'{"stream":"Removing intermediate container 3600c91d1c40\\n"}\r\n',
+     b'{"stream":"Successfully built 1793c2380436\\n"}\r\n']
+
+mock_build_logs_failed = mock_build_logs + \
+    [b'{"errorDetail":{"code":2,"message":"The command \\u0026{[/bin/sh -c ls -lha /a/b/c]} returned a non-zero code: 2"},\
+        "error":"The command \\u0026{[/bin/sh -c ls -lha /a/b/c]} returned a non-zero code: 2"}\r\n']
+
+mock_pull_logs = \
+    [b'{"stream":"Trying to pull repository localhost:5000/busybox ..."}\r\n',
+     b'{"status":"Pulling image (latest) from localhost:5000/busybox","progressDetail":{},"id":"8c2e06607696"}',
+     b'{"status":"Download complete","progressDetail":{},"id":"8c2e06607696"}',
+     b'{"status":"Status: Image is up to date for localhost:5000/busybox:latest"}\r\n']
+
+mock_push_logs = \
+    b'{"status":"The push refers to a repository [localhost:5000/dock-tests-b3a11e13d27c428f8fa2914c8c6a6d96] (len: 1)"}\r\n' \
+    b'{"errorDetail":{"message":"Repository does not exist: localhost:5000/dock-tests-b3a11e13d27c428f8fa2914c8c6a6d96"},' \
+    b'"error":"Repository does not exist: localhost:5000/dock-tests-b3a11e13d27c428f8fa2914c8c6a6d96"}\r\n'
+
+
+def mock_docker(build_should_fail=False, inspect_should_fail=False, provided_image_repotags=None):
+    if provided_image_repotags:
+        mock_image['RepoTags'] = provided_image_repotags
+    build_result = iter(mock_build_logs_failed) if build_should_fail else iter(mock_build_logs)
+    inspect_result = None if inspect_should_fail else mock_image
+
+    flexmock(docker.Client, build=lambda **kwargs: build_result)
+    flexmock(docker.Client, commit=lambda cid, **kwargs: mock_containers[0])
+    flexmock(docker.Client, containers=lambda **kwargs: mock_containers)
+    flexmock(docker.Client, create_container=lambda img, **kwargs: mock_containers[0])
+    flexmock(docker.Client, images=lambda **kwargs: [mock_image])
+    flexmock(docker.Client, inspect_image=lambda im_id: inspect_result)
+    flexmock(docker.Client, logs=lambda cid, **kwargs: iter([mock_logs]) if kwargs.get('stream') else mock_logs)
+    flexmock(docker.Client, pull=lambda img, **kwargs: iter(mock_pull_logs))
+    flexmock(docker.Client, push=lambda iid, **kwargs: mock_push_logs)
+    flexmock(docker.Client, remove_container=lambda cid, **kwargs: None)
+    flexmock(docker.Client, remove_image=lambda iid, **kwargs: None)
+    flexmock(docker.Client, start=lambda cid, **kwargs: None)
+    flexmock(docker.Client, tag=lambda img, rep, **kwargs: True)
+    flexmock(docker.Client, wait=lambda cid: 1)
+    flexmock(os.path, exists=lambda path: True)  # DOCKER_SOCKET_PATH check

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -40,8 +40,8 @@ CMD blabla"""
         tasker,
         workflow,
         [{
-             'name': AddLabelsPlugin.key,
-             'args': {'labels': labels_conf}
+            'name': AddLabelsPlugin.key,
+            'args': {'labels': labels_conf}
         }]
     )
     runner.run()

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -5,7 +5,10 @@ from dock.inner import DockerBuildWorkflow
 from dock.plugin import PostBuildPluginsRunner
 from dock.plugins.post_tag_and_push import TagAndPushPlugin
 from dock.util import ImageName
-from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE
+from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK
+
+if MOCK:
+    from tests.docker_mock import mock_docker
 
 
 class X(object):
@@ -16,6 +19,9 @@ class X(object):
 
 
 def test_tag_and_push_plugin(tmpdir):
+    if MOCK:
+        mock_docker()
+
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow("asd", "test-image")
     setattr(workflow, 'builder', X)

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -6,7 +6,10 @@ from dock.plugin import PostBuildPluginsRunner
 from dock.plugins.post_tag_and_push import TagAndPushPlugin
 from dock.plugins.post_tag_by_labels import TagByLabelsPlugin
 from dock.util import ImageName
-from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE
+from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK
+
+if MOCK:
+    from tests.docker_mock import mock_docker
 
 
 class X(object):
@@ -17,6 +20,9 @@ class X(object):
 
 
 def test_tag_by_labels_plugin(tmpdir):
+    if MOCK:
+        mock_docker()
+
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow("asd", "test-image")
     version = "1.0"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+flexmock
+ordereddict
+pytest

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,9 +1,11 @@
 from dock.build import InsideBuilder
 from dock.core import DockerTasker
 from dock.util import ImageName
-from constants import LOCALHOST_REGISTRY, DOCKERFILE_GIT
+from tests.constants import LOCALHOST_REGISTRY, DOCKERFILE_GIT, MOCK
 
-#
+if MOCK:
+    from tests.docker_mock import mock_docker
+
 # This stuff is used in tests; you have to have internet connection,
 # running registry on port 5000 and it helps if you've pulled fedora:latest before
 git_base_repo = "fedora"
@@ -12,6 +14,9 @@ git_base_image = ImageName(registry=LOCALHOST_REGISTRY, repo="fedora", tag="late
 
 
 def test_pull_base_image(tmpdir):
+    if MOCK:
+        mock_docker()
+
     t = DockerTasker()
     b = InsideBuilder(DOCKERFILE_GIT, "", tmpdir=str(tmpdir))
     reg_img_name = b.pull_base_image(LOCALHOST_REGISTRY, insecure=True)
@@ -24,8 +29,11 @@ def test_pull_base_image(tmpdir):
 
 
 def test_build_image(tmpdir):
-    t = DockerTasker()
     provided_image = "test-build:test_tag"
+    if MOCK:
+        mock_docker(provided_image_repotags=provided_image)
+
+    t = DockerTasker()
     b = InsideBuilder(DOCKERFILE_GIT, provided_image, tmpdir=str(tmpdir))
     build_result = b.build()
     assert t.inspect_image(build_result.image_id)
@@ -34,19 +42,23 @@ def test_build_image(tmpdir):
 
 
 def test_build_error_dockerfile(tmpdir):
-    t = DockerTasker()
     provided_image = "test-build:test_tag"
+    if MOCK:
+        mock_docker(build_should_fail=True, provided_image_repotags=provided_image)
+
     b = InsideBuilder(DOCKERFILE_GIT, provided_image, git_commit="error-build", tmpdir=str(tmpdir))
     build_result = b.build()
     assert build_result.is_failed()
 
 
 def test_inspect_built_image(tmpdir):
-    t = DockerTasker()
     provided_image = "test-build:test_tag"
+    if MOCK:
+        mock_docker(provided_image_repotags=provided_image)
+
+    t = DockerTasker()
     b = InsideBuilder(DOCKERFILE_GIT, provided_image, tmpdir=str(tmpdir))
     build_result = b.build()
-
     built_inspect = b.inspect_built_image()
 
     assert built_inspect is not None
@@ -57,8 +69,10 @@ def test_inspect_built_image(tmpdir):
 
 
 def test_inspect_base_image(tmpdir):
-    b = InsideBuilder(DOCKERFILE_GIT, '', tmpdir=str(tmpdir))
+    if MOCK:
+        mock_docker()
 
+    b = InsideBuilder(DOCKERFILE_GIT, '', tmpdir=str(tmpdir))
     built_inspect = b.inspect_base_image()
 
     assert built_inspect is not None
@@ -66,8 +80,10 @@ def test_inspect_base_image(tmpdir):
 
 
 def test_get_base_image_info(tmpdir):
-    b = InsideBuilder(DOCKERFILE_GIT, '', tmpdir=str(tmpdir))
+    if MOCK:
+        mock_docker(provided_image_repotags='fedora:latest')
 
+    b = InsideBuilder(DOCKERFILE_GIT, '', tmpdir=str(tmpdir))
     built_inspect = b.get_base_image_info()
 
     assert built_inspect is not None

--- a/tests/test_buildimage.py
+++ b/tests/test_buildimage.py
@@ -4,6 +4,10 @@ import os
 from dock.buildimage import BuildImageBuilder
 from dock.core import DockerTasker
 
+from tests.constants import MOCK
+
+if MOCK:
+    from tests.docker_mock import mock_docker
 
 PARENT_DIR = os.path.dirname(os.path.dirname(__file__))
 TEST_BUILD_IMAGE = "test-build-image"
@@ -24,6 +28,9 @@ def test_tarball_generation_upstream_repo(tmpdir):
 
 
 def test_image_creation_upstream_repo():
+    if MOCK:
+        mock_docker()
+
     b = BuildImageBuilder(use_official_dock_git=True)
     df_dir_path = os.path.join(PARENT_DIR, 'images', 'privileged-builder')
     b.create_image(df_dir_path, TEST_BUILD_IMAGE)
@@ -34,6 +41,9 @@ def test_image_creation_upstream_repo():
 
 
 def test_image_creation_local_repo():
+    if MOCK:
+        mock_docker()
+
     b = BuildImageBuilder(dock_local_path=PARENT_DIR)
     df_dir_path = os.path.join(PARENT_DIR, 'images', 'privileged-builder')
     b.create_image(df_dir_path, TEST_BUILD_IMAGE)

--- a/tests/test_dock.py
+++ b/tests/test_dock.py
@@ -1,9 +1,15 @@
 from dock.core import DockerTasker
 from dock.outer import PrivilegedBuildManager, DockerhostBuildManager
 from dock.util import ImageName
-from constants import LOCALHOST_REGISTRY, DOCKERFILE_GIT, TEST_IMAGE
+from tests.constants import LOCALHOST_REGISTRY, DOCKERFILE_GIT, TEST_IMAGE, MOCK
+
+if MOCK:
+    from tests.docker_mock import mock_docker
 
 def test_hostdocker_build():
+    if MOCK:
+        mock_docker()
+
     image_name = ImageName(repo="dock-test-ssh-image")
     remote_image = image_name.copy()
     remote_image.registry = LOCALHOST_REGISTRY
@@ -17,7 +23,7 @@ def test_hostdocker_build():
     })
     results = m.build()
     dt = DockerTasker()
-    img = dt.pull_image(remote_image, insecure=True)
+    dt.pull_image(remote_image, insecure=True)
     assert len(results.build_logs) > 0
     # assert isinstance(results.built_img_inspect, dict)
     # assert len(results.built_img_inspect.items()) > 0
@@ -32,6 +38,9 @@ def test_hostdocker_build():
 
 
 def test_hostdocker_error_build():
+    if MOCK:
+        mock_docker()
+
     image_name = TEST_IMAGE
     m = DockerhostBuildManager("buildroot-dh-fedora", {
         "git_url": DOCKERFILE_GIT,
@@ -49,6 +58,9 @@ def test_hostdocker_error_build():
 
 
 def test_privileged_gitrepo_build():
+    if MOCK:
+        mock_docker()
+
     image_name = ImageName(repo="dock-test-ssh-image")
     remote_image = image_name.copy()
     remote_image.registry = LOCALHOST_REGISTRY
@@ -62,7 +74,7 @@ def test_privileged_gitrepo_build():
     })
     results = m.build()
     dt = DockerTasker()
-    img = dt.pull_image(remote_image, insecure=True)
+    dt.pull_image(remote_image, insecure=True)
     assert len(results.build_logs) > 0
     # assert isinstance(results.built_img_inspect, dict)
     # assert len(results.built_img_inspect.items()) > 0
@@ -76,6 +88,9 @@ def test_privileged_gitrepo_build():
     dt.remove_image(remote_image)
 
 def test_privileged_build():
+    if MOCK:
+        mock_docker()
+
     image_name = ImageName(repo=TEST_IMAGE)
     remote_image = image_name.copy()
     remote_image.registry = LOCALHOST_REGISTRY
@@ -88,7 +103,7 @@ def test_privileged_build():
     })
     results = m.build()
     dt = DockerTasker()
-    img = dt.pull_image(remote_image, insecure=True)
+    dt.pull_image(remote_image, insecure=True)
     assert len(results.build_logs) > 0
     # assert isinstance(results.built_img_inspect, dict)
     # assert len(results.built_img_inspect.items()) > 0

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,7 +5,7 @@ from dock.inner import DockerBuildWorkflow
 from dock.plugin import PreBuildPluginsRunner, PostBuildPluginsRunner, InputPluginsRunner
 from dock.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from dock.util import ImageName
-from constants import DOCKERFILE_GIT
+from tests.constants import DOCKERFILE_GIT
 
 
 TEST_IMAGE = "fedora:latest"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,10 @@ import os
 import docker
 from dock.util import ImageName, get_baseimage_from_dockerfile, wait_for_command, \
                       clone_git_repo, LazyGit, figure_out_dockerfile
-from tests.constants import DOCKERFILE_GIT, INPUT_IMAGE
+from tests.constants import DOCKERFILE_GIT, INPUT_IMAGE, MOCK
 
+if MOCK:
+    from tests.docker_mock import mock_docker
 
 TEST_DATA = {
     "repository.com/image-name": ImageName(registry="repository.com", repo="image-name"),
@@ -31,6 +33,9 @@ def test_image_name_format():
 
 
 def test_wait_for_command():
+    if MOCK:
+        mock_docker()
+
     d = docker.Client()
     logs_gen = d.pull(INPUT_IMAGE, stream=True)
     assert wait_for_command(logs_gen) is not None


### PR DESCRIPTION
I haven't split the tests to unit & integration tests.

By default all docker.Client methods are now mocked (using flexmock),
so you don't need docker to run these tests.
If you want to run 'integration' tests, i.e. with running docker
instance, set NOMOCK environment variable:
$ NOMOCK=1 py.test -v

It needs some more polishing, but seems to work fine so far at least for Python 2.
https://travis-ci.org/jpopelka/dock/builds