### PR TITLE
GitPython -> git, clone only single branch

### DIFF
--- a/dock.spec
+++ b/dock.spec
@@ -22,6 +22,8 @@ BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 Requires:       python-dock
 
+Requires:       git >= 1.7.10
+
 %if 0%{?with_python3}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -81,8 +83,6 @@ License:        BSD
 Requires:       python3-docker-py
 Requires:       python3-requests
 Requires:       python3-setuptools
-# python3 build is missing for GitPython
-Requires:       GitPython
 
 %description -n python3-dock
 Simple Python 3 library for building docker images. It contains

--- a/dock/core.py
+++ b/dock/core.py
@@ -21,7 +21,6 @@ import logging
 import tempfile
 import datetime
 
-import git
 import docker
 from docker.errors import APIError
 

--- a/dock/util.py
+++ b/dock/util.py
@@ -4,9 +4,9 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import logging
-import git
 from dock.constants import DOCKERFILE_FILENAME
 
 __author__ = 'ttomecek'
@@ -187,12 +187,14 @@ def clone_git_repo(git_url, target_dir, commit=None):
     :param commit: str, commit to checkout
     :return:
     """
+    commit = commit or "master"
     logger.info("clone git repo")
     logger.debug("url = '%s', dir = '%s', commit = '%s'",
                  git_url, target_dir, commit)
-    repo = git.Repo.clone_from(git_url, target_dir)
-    if commit:
-        repo.git.checkout(commit)
+
+    # http://stackoverflow.com/questions/1911109/clone-a-specific-git-branch/4568323#4568323
+    cmd = ["git", "clone", "-b", commit, "--single-branch", git_url, target_dir]
+    subprocess.check_call(cmd)
 
 
 def figure_out_dockerfile(absolute_path, local_path=None):

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -3,10 +3,9 @@ from __future__ import print_function
 from tests.fixtures import temp_image_name
 
 from dock.core import DockerTasker
-from dock.util import ImageName
+from dock.util import ImageName, clone_git_repo
 from tests.constants import LOCALHOST_REGISTRY, INPUT_IMAGE, DOCKERFILE_GIT, MOCK, COMMAND
 
-import git
 import docker, docker.errors
 import pytest
 
@@ -257,7 +256,7 @@ def test_build_image_from_path(tmpdir, temp_image_name):
         mock_docker()
 
     tmpdir_path = str(tmpdir.realpath())
-    git.Repo.clone_from(DOCKERFILE_GIT, tmpdir_path)
+    clone_git_repo(DOCKERFILE_GIT, tmpdir_path)
     df = tmpdir.join("Dockerfile")
     assert df.check()
     t = DockerTasker()


### PR DESCRIPTION
GitPython uses git command so why we should have such dep when in the
end we use it only to clone a git repo

Fixes #68