### PR TITLE
Add squashing plugin

### DIFF
--- a/dock/plugins/prepub_squash.py
+++ b/dock/plugins/prepub_squash.py
@@ -1,0 +1,54 @@
+from dock.plugin import PrePublishPlugin
+from docker_scripts.squash import Squash
+
+__all__ = ('PrePublishSquashPlugin', )
+
+
+class PrePublishSquashPlugin(PrePublishPlugin):
+
+    """
+    This feature requires docker-scripts package to be installed in version 0.3.2
+    or higher.
+
+    Usage:
+
+    A json build config file should be created with following content:
+
+    ```
+      "prepublish_plugins": [{
+        "name": "squash",
+          "args": {
+            "tag": "SQUASH_TAG",
+            "from_layer": "FROM_LAYER"
+          }
+        }
+      }
+    ```
+
+    The `tag` argument specifes the tag under which the new squashed image will
+    be registered. The `from_layer` argument specifies from which layer we want
+    to squash.
+
+    Of course it's possible to override it at runtime, like this: `--substitute prepublish_plugins.squash.tag=image:squashed
+      --substitute prepublish_plugins.squash.from_layer=asdasd2332`.
+    """
+
+    key = "squash"
+    # Fail the build in case of squashing error
+    can_fail = False
+
+    def __init__(self, tasker, workflow, tag, from_layer=None):
+        """
+        :param tasker: DockerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param from_layer: The layer from we will squash - by default it'll be the first layer
+        :param tag: What should be used to tag the squashed the image.
+        """
+        super(PrePublishSquashPlugin, self).__init__(tasker, workflow)
+        self.image = self.workflow.builder.image_id
+        self.from_layer = from_layer
+        self.tag = tag
+
+    def run(self):
+        Squash(log=self.log, image=self.image,
+               from_layer=self.from_layer, tag=self.tag).run()


### PR DESCRIPTION
This commit adds squashing support for in Dock.

This feature requires docker-scripts package to be installed.

Usage:

A json build config file should be created with following content:

```
  "prepublish_plugins": [{
    "name": "squash",
      "args": {
        "tag": "SQUASH_TAG",
        "from_layer": "FROM_LAYER"
      }
    }
  }
```

The `tag` argument specifes the tag under which the new squashed image will
be registered. The `from_layer` argument specifies from which layer we want
to squash.

Of course it's possible to override it at runtime, like this: `--substitute prepublish_plugins.squash.tag=image:squashed
  --substitute prepublish_plugins.squash.from_layer=asdasd2332`.

It requires docker-scripts `0.3.2` or newer.