### PR TITLE
build: always pull base image

### DIFF
--- a/dock/build.py
+++ b/dock/build.py
@@ -116,17 +116,19 @@ class InsideBuilder(LastLogger, LazyGit, BuilderStateMachine):
         logger.info("pull base image from registry")
         self._ensure_not_built()
 
-        # registry in dockerfile doesn't match provided source registry
-        if self.base_image.registry and self.base_image.registry != source_registry:
-            logger.error("registry in dockerfile doesn't match provided source registry, "
-                         "dockerfile = '%s', provided = '%s'",
-                         self.base_image.registry, source_registry)
-            raise RuntimeError(
-                "Registry specified in dockerfile doesn't match provided one. Dockerfile: '%s', Provided: '%s'"
-                % (self.base_image.registry, source_registry))
-
         base_image_with_registry = self.base_image.copy()
-        base_image_with_registry.registry = source_registry
+
+        if source_registry:
+            # registry in dockerfile doesn't match provided source registry
+            if self.base_image.registry and self.base_image.registry != source_registry:
+                logger.error("registry in dockerfile doesn't match provided source registry, "
+                             "dockerfile = '%s', provided = '%s'",
+                             self.base_image.registry, source_registry)
+                raise RuntimeError(
+                    "Registry specified in dockerfile doesn't match provided one. Dockerfile: '%s', Provided: '%s'"
+                    % (self.base_image.registry, source_registry))
+
+            base_image_with_registry.registry = source_registry
 
         base_image = self.tasker.pull_image(base_image_with_registry, insecure=insecure)
 

--- a/dock/inner.py
+++ b/dock/inner.py
@@ -186,9 +186,8 @@ class DockerBuildWorkflow(object):
         self.builder = InsideBuilder(self.git_url, self.image, git_dockerfile_path=self.git_dockerfile_path,
                                      git_commit=self.git_commit, tmpdir=tmpdir)
         try:
-            if self.parent_registry:
-                self.pulled_base_image = self.builder.pull_base_image(
-                    self.parent_registry, insecure=self.parent_registry_insecure)
+            self.pulled_base_image = self.builder.pull_base_image(
+                self.parent_registry, insecure=self.parent_registry_insecure)
 
             # time to run pre-build plugins, so they can access cloned repo,
             # base image


### PR DESCRIPTION
Some prebuild plugins may require base image to be present on a system
(e.g. changing FROM). Let's pull the base image prior to evey build.

Resolves #81
