### PR TITLE
add dockerfile: snapshot dockerfile

### DIFF
--- a/dock/plugins/pre_add_dockerfile.py
+++ b/dock/plugins/pre_add_dockerfile.py
@@ -72,6 +72,7 @@ class AddDockerfilePlugin(PreBuildPlugin):
             if name is None or version is None or release is None:
                 raise ValueError("You have to specify either nvr arg or Name/Version/Release labels.")
             nvr = "{0}-{1}-{2}".format(name, version, release)
+            nvr = nvr.replace("/", "-")
         self.df_name = '{0}-{1}'.format(DOCKERFILE_FILENAME, nvr)
         self.df_dir = destdir
         self.df_path = os.path.join(self.df_dir, self.df_name)

--- a/dock/plugins/pre_add_dockerfile.py
+++ b/dock/plugins/pre_add_dockerfile.py
@@ -37,6 +37,7 @@ or
 """
 
 import os
+import shutil
 from dock.constants import DOCKERFILE_FILENAME
 from dock.util import get_labels_from_dockerfile
 from dock.plugin import PreBuildPlugin
@@ -45,7 +46,8 @@ from dock.plugin import PreBuildPlugin
 class AddDockerfilePlugin(PreBuildPlugin):
     key = "add_dockerfile"
 
-    def __init__(self, tasker, workflow, nvr=None, destdir="/root/buildinfo/"):
+    def __init__(self, tasker, workflow, nvr=None, destdir="/root/buildinfo/",
+                 use_final_dockerfile=False):
         """
         constructor
 
@@ -54,9 +56,14 @@ class AddDockerfilePlugin(PreBuildPlugin):
         :param nvr: name-version-release, will be appended to Dockerfile-.
                     If not specified, try to get it from Name, Version, Release labels.
         :param destdir: directory in the image to put Dockerfile-N-V-R into
+        :param use_final_dockerfile: bool, when set to True, uses final version of processed dockerfile,
+                                     when set to False, uses Dockerfile from time when this plugin was executed
         """
         # call parent constructor
         super(AddDockerfilePlugin, self).__init__(tasker, workflow)
+
+        self.use_final_dockerfile = use_final_dockerfile
+
         if nvr is None:
             labels = get_labels_from_dockerfile(self.workflow.builder.df_path)
             name = labels.get('Name')
@@ -69,6 +76,11 @@ class AddDockerfilePlugin(PreBuildPlugin):
         self.df_dir = destdir
         self.df_path = os.path.join(self.df_dir, self.df_name)
 
+        # we are not using final dockerfile, so let's copy current snapshot
+        if not self.use_final_dockerfile:
+            local_df_path = os.path.join(self.workflow.builder.df_dir, self.df_name)
+            shutil.copy2(self.workflow.builder.df_path, local_df_path)
+
     def run(self):
         """
         run the plugin
@@ -76,7 +88,12 @@ class AddDockerfilePlugin(PreBuildPlugin):
         with open(self.workflow.builder.df_path, 'r') as fp:
             lines = fp.readlines()
 
-        content = 'ADD {0} {1}'.format(DOCKERFILE_FILENAME, self.df_path)
+        # when using final dockerfile, we should use DOCKERFILE_FILENAME
+        # otherwise we should use the copied version
+        if self.use_final_dockerfile:
+            content = 'ADD {0} {1}'.format(DOCKERFILE_FILENAME, self.df_path)
+        else:
+            content = 'ADD {0} {1}'.format(self.df_name, self.df_path)
 
         # put it before last instruction
         lines.insert(-1, content + '\n')


### PR DESCRIPTION
If we edit dockerfile after running "add" plugin, we may expose some
unwanted information.

This patch copies dockerfile when the "add" plugin is run and stores
that snapshot in final image.

CC @jpopelka 
Related #108 

As I think about it, this new behavior should be configurable. What do you think Jirko?

(please don't merge)