### PR TITLE
remove_built_image: force removal of base image

### DIFF
--- a/dock/build.py
+++ b/dock/build.py
@@ -123,14 +123,14 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
             base_image_with_registry.registry = source_registry
 
         base_image = self.tasker.pull_image(base_image_with_registry, insecure=insecure)
+        pulled_tags = set([base_image])
 
         if not self.base_image.registry:
             response = self.tasker.tag_image(base_image_with_registry, self.base_image, force=True)
-        else:
-            response = base_image
+            pulled_tags.add(response)
 
         logger.debug("image '%s' is available", response)
-        return response
+        return pulled_tags
 
     def build(self):
         """

--- a/dock/inner.py
+++ b/dock/inner.py
@@ -165,7 +165,7 @@ class DockerBuildWorkflow(object):
         self.built_image_inspect = None
 
         self.dont_pull_base_image = dont_pull_base_image
-        self.pulled_base_image = None
+        self.pulled_base_images = set()
 
         # squashed image tarball
         # set by squash plugin
@@ -192,8 +192,8 @@ class DockerBuildWorkflow(object):
         self.builder = InsideBuilder(self.source, self.image)
         try:
             if not self.dont_pull_base_image:
-                self.pulled_base_image = self.builder.pull_base_image(self.parent_registry,
-                                                                      insecure=self.parent_registry_insecure)
+                self.pulled_base_images = self.builder.pull_base_image(self.parent_registry,
+                                                                       insecure=self.parent_registry_insecure)
 
             # time to run pre-build plugins, so they can access cloned repo,
             # base image

--- a/docs/api.md
+++ b/docs/api.md
@@ -318,7 +318,7 @@ Python API for dock. This is the official way of interacting with dock.
 
 * prepublish_plugins_conf
 
-* pulled_base_image
+* pulled_base_images
 
 * repos
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -41,11 +41,14 @@ def test_pull_base_image(tmpdir, source_params):
     s = get_source_instance_for(source_params)
     t = DockerTasker()
     b = InsideBuilder(s, "")
-    reg_img_name = b.pull_base_image(LOCALHOST_REGISTRY, insecure=True)
-    reg_img_name = ImageName.parse(reg_img_name)
-    assert t.inspect_image(reg_img_name) is not None
-    assert reg_img_name.repo == git_base_image.repo
-    assert reg_img_name.tag == git_base_image.tag
+    pulled_tags = b.pull_base_image(LOCALHOST_REGISTRY, insecure=True)
+    assert isinstance(pulled_tags, set)
+    assert len(pulled_tags) == 2
+    for reg_img_name in pulled_tags:
+        reg_img_name = ImageName.parse(reg_img_name)
+        assert t.inspect_image(reg_img_name) is not None
+        assert reg_img_name.repo == git_base_image.repo
+        assert reg_img_name.tag == git_base_image.tag
     # clean
     t.remove_image(git_base_image)
 


### PR DESCRIPTION
Fixes #125.

Removal should be safe since we are referring to the image by name which means we just untag it?

This gets rid of the error message in #125 but the base image handling has still problems when it comes to concurrent builds (see e.g. #135).