### PR TITLE
refactor pushing logic

### DIFF
--- a/dock/plugins/post_store_metadata_in_osv3.py
+++ b/dock/plugins/post_store_metadata_in_osv3.py
@@ -63,6 +63,8 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
         # FIXME: use OSBS here
         o = Openshift(api_url, oauth_url, None, use_auth=self.use_auth, verify_ssl=self.verify_ssl)
 
+        # usually repositories formed from NVR labels
+        # these should be used for pulling and layering
         primary_repositories = []
         for registry in self.workflow.push_conf.all_registries:
             for image in self.workflow.tag_conf.images:
@@ -70,6 +72,7 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
                 registry_image.registry = registry.uri
                 primary_repositories.append(registry_image.to_str())
 
+        # unique unpredictable repositories
         unique_repositories = []
         target_image = self.workflow.builder.image.copy()
         for registry in self.workflow.push_conf.all_registries:

--- a/dock/plugins/post_store_metadata_in_osv3.py
+++ b/dock/plugins/post_store_metadata_in_osv3.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals
 import json
 import os
 from osbs.core import Openshift
-from dock.util import ImageName
 
 try:
     # py2
@@ -61,27 +60,20 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
 
         # initial setup will use host based auth: apache will be set to accept everything
         # from specific IP and will set specific X-Remote-User for such requests
+        # FIXME: use OSBS here
         o = Openshift(api_url, oauth_url, None, use_auth=self.use_auth, verify_ssl=self.verify_ssl)
 
         primary_repositories = []
-        for registry_uri in self.workflow.tag_and_push_conf.registries:
-            registry_conf = self.workflow.tag_and_push_conf[registry_uri]
-            try:
-                image_names = registry_conf['image_names']
-            except KeyError:
-                self.log.error("Registry '%s' doesn't have any image names, skipping...", registry_uri)
-                continue
-            for image in image_names:
-                image_name = ImageName.parse(image)
-                if image_name.registry:
-                    assert image_name.registry == registry_uri
-                image_name.registry = registry_uri
-                primary_repositories.append(image_name.to_str())
+        for registry in self.workflow.push_conf.all_registries:
+            for image in self.workflow.tag_conf.images:
+                registry_image = image.copy()
+                registry_image.registry = registry.uri
+                primary_repositories.append(registry_image.to_str())
 
         unique_repositories = []
         target_image = self.workflow.builder.image.copy()
-        for registry in self.workflow.target_registries:
-            target_image.registry = registry
+        for registry in self.workflow.push_conf.all_registries:
+            target_image.registry = registry.uri
             unique_repositories.append(target_image.to_str())
 
         repositories = {

--- a/dock/plugins/post_tag_and_push.py
+++ b/dock/plugins/post_tag_and_push.py
@@ -7,7 +7,6 @@ of the BSD license. See the LICENSE file for details.
 """
 
 from dock.plugin import PostBuildPlugin
-from dock.util import ImageName
 
 
 __all__ = ('TagAndPushPlugin', )
@@ -17,48 +16,24 @@ class TagAndPushPlugin(PostBuildPlugin):
     key = "tag_and_push"
     can_fail = False
 
-    def __init__(self, tasker, workflow, mapping=None, insecure=False):
+    def __init__(self, tasker, workflow, **kwargs):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
-        :param mapping: dict, map with following structure (insecure in
-                              mapping overrides global insecure):
-          {
-            "<registry_uri>": {
-              "insecure": false,
-              "image_names": [
-                "image-name1",
-                "prefix/image-name2",
-              ],
-            }
-            "...": {...}
-          }
-        :param insecure: bool, allow connection to registry to be insecure
         """
         # call parent constructor
         super(TagAndPushPlugin, self).__init__(tasker, workflow)
-        self.mapping = mapping
-        self.insecure = insecure
+        self.log.warning("Ignoring arguments %s", kwargs)
 
     def run(self):
         pushed_images = []
-        self.workflow.tag_and_push_conf.merge_with_mapping(self.mapping)
-        for registry_uri in self.workflow.tag_and_push_conf.registries:
-            registry_conf = self.workflow.tag_and_push_conf[registry_uri]
-            insecure = registry_conf.get("insecure", self.insecure)
-            try:
-                image_names = registry_conf['image_names']
-            except KeyError:
-                self.log.error("Registry '%s' doesn't have any image names, skipping...", registry_uri)
-                continue
-            for image in image_names:
-                image_name = ImageName.parse(image)
-                if image_name.registry:
-                    assert image_name.registry == registry_uri
-                image_name.registry = registry_uri
-                self.tasker.tag_and_push_image(self.workflow.builder.image_id, image_name,
-                                               insecure=insecure, force=True)
-                pushed_images.append(image_name.to_str())
+        for registry in self.workflow.push_conf.all_docker_registries:
+            for image in self.workflow.tag_conf.images:
+                registry_image = image.copy()
+                registry_image.registry = registry.uri
+                self.tasker.tag_and_push_image(self.workflow.builder.image_id, registry_image,
+                                               insecure=registry.insecure, force=True)
+                pushed_images.append(registry_image.to_str())
         return pushed_images

--- a/dock/plugins/post_tag_and_push.py
+++ b/dock/plugins/post_tag_and_push.py
@@ -13,6 +13,10 @@ __all__ = ('TagAndPushPlugin', )
 
 
 class TagAndPushPlugin(PostBuildPlugin):
+    """
+    Use tags from workflow.tag_conf and push the images to workflow.push_conf
+    """
+
     key = "tag_and_push"
     can_fail = False
 
@@ -29,7 +33,7 @@ class TagAndPushPlugin(PostBuildPlugin):
 
     def run(self):
         pushed_images = []
-        for registry in self.workflow.push_conf.all_docker_registries:
+        for registry in self.workflow.push_conf.docker_registries:
             for image in self.workflow.tag_conf.images:
                 registry_image = image.copy()
                 registry_image.registry = registry.uri

--- a/dock/plugins/post_tag_by_labels.py
+++ b/dock/plugins/post_tag_by_labels.py
@@ -13,6 +13,11 @@ __all__ = ('TagByLabelsPlugin', )
 
 
 class TagByLabelsPlugin(PostBuildPlugin):
+    """
+    Use labels Name, Version and Release of final image and create tags:
+     * Name:Version
+     * Name:Version_Release
+    """
     key = "tag_by_labels"
     can_fail = False
 

--- a/dock/plugins/post_tag_by_labels.py
+++ b/dock/plugins/post_tag_by_labels.py
@@ -16,19 +16,16 @@ class TagByLabelsPlugin(PostBuildPlugin):
     key = "tag_by_labels"
     can_fail = False
 
-    def __init__(self, tasker, workflow, registry_uri, insecure=False):
+    def __init__(self, tasker, workflow, **kwargs):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
-        :param registry_uri: str, registry URI where the image should be pushed
-        :param insecure: bool, allow connection to registry to be insecure
         """
         # call parent constructor
         super(TagByLabelsPlugin, self).__init__(tasker, workflow)
-        self.registry_uri = registry_uri
-        self.insecure = insecure
+        self.log.warning("Ignoring arguments %s", kwargs)
 
     def run(self):
         if not self.workflow.built_image_inspect:
@@ -50,7 +47,4 @@ class TagByLabelsPlugin(PostBuildPlugin):
         nvr = "%s:%s_%s" % (name, version, release)
         nv = "%s:%s" % (name, version)
 
-        target_registries_insecure = self.insecure or self.workflow.target_registries_insecure
-
-        self.workflow.tag_and_push_conf.add_image(self.registry_uri, nvr, target_registries_insecure)
-        self.workflow.tag_and_push_conf.add_image(self.registry_uri, nv, target_registries_insecure)
+        self.workflow.tag_conf.add_images([nvr, nv])

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -36,7 +36,9 @@ def test_tag_and_push_plugin(tmpdir):
         mock_docker()
 
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, "test-image")
+    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow.tag_conf.add_image(TEST_IMAGE)
+    workflow.push_conf.add_docker_registry(LOCALHOST_REGISTRY, insecure=True)
     setattr(workflow, 'builder', X)
 
     runner = PostBuildPluginsRunner(
@@ -44,16 +46,6 @@ def test_tag_and_push_plugin(tmpdir):
         workflow,
         [{
             'name': TagAndPushPlugin.key,
-            'args': {
-                "mapping": {
-                    LOCALHOST_REGISTRY: {
-                        "insecure": True,
-                        "image_names": [
-                            TEST_IMAGE
-                        ]
-                    }
-                }
-            }
         }]
     )
     output = runner.run()

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -49,6 +49,7 @@ def test_tag_by_labels_plugin(tmpdir):
             }
         }
     }
+    workflow.push_conf.add_docker_registry(LOCALHOST_REGISTRY, insecure=True)
     image = ImageName(repo=TEST_IMAGE,
                       tag="%s_%s" % (version, release),
                       registry=LOCALHOST_REGISTRY)
@@ -60,10 +61,6 @@ def test_tag_by_labels_plugin(tmpdir):
         workflow,
         [{
             'name': TagByLabelsPlugin.key,
-            'args': {
-                "registry_uri": LOCALHOST_REGISTRY,
-                "insecure": True,
-            }
         }, {
             'name': TagAndPushPlugin.key,
         }]


### PR DESCRIPTION
so we can consume pulp more easily

This patch removes functionality! "tag by labels" and "tag and push"
plugins lost some arguments:

 * tag and push

   No longer accepts any arguments, it just pushes everything from
   tag_conf to push_conf

 * tag by labels

   No longer accepts any arguments, it just puts images inside tag_conf

Fixes #142