### PR TITLE
Make sure that 'source' isn't repeated twice for path provider

### DIFF
--- a/dock/core.py
+++ b/dock/core.py
@@ -92,13 +92,11 @@ class BuildContainerFactory(object):
         build_json_path = os.path.join(local_path, BUILD_JSON)
         with open(build_json_path, 'r') as fp:
             build_json = json.load(fp)
-        save_code_to = os.path.join(local_path, CONTAINER_SHARE_SOURCE_SUBDIR)
-        os.mkdir(save_code_to)
-        source = get_source_instance_for(build_json['source'], tmpdir=save_code_to)
+        source = get_source_instance_for(build_json['source'], tmpdir=local_path)
         if source.provider == 'path':
-            logger.debug('Copying source from %s to %s', source.schemeless_path, save_code_to)
+            logger.debug('Copying source from %s to %s', source.schemeless_path, local_path)
             source.get()
-            logger.debug('Verifying that %s exists: %s', save_code_to, os.path.exists(save_code_to))
+            logger.debug('Verifying that %s exists: %s', local_path, os.path.exists(local_path))
             # now modify the build json
             build_json['source']['uri'] =\
                     'file://' + os.path.join(container_path, CONTAINER_SHARE_SOURCE_SUBDIR)

--- a/dock/source.py
+++ b/dock/source.py
@@ -30,9 +30,9 @@ class Source(object):
         self.provider_params = provider_params or {}
         # TODO: do we want to delete tmpdir when destroying the object?
         self.tmpdir = tmpdir or tempfile.mkdtemp()
-        logger.debug("workdir is '%s'", repr(self.tmpdir))
+        logger.debug("workdir is %s", repr(self.tmpdir))
         self.source_path = os.path.join(self.tmpdir, SOURCE_DIRECTORY_NAME)
-        logger.debug("source path is '%s'", repr(self.source_path))
+        logger.debug("source path is %s", repr(self.source_path))
 
     @property
     def path(self):

--- a/tests/test_dock.py
+++ b/tests/test_dock.py
@@ -40,10 +40,14 @@ def assert_source_from_path_mounted_ok(caplog, tmpdir):
 
     # verify that source code was copied in - actually only verifies
     #  that source dir has been created
-    source_exists = 'Verifying that %s exists: True' %\
+    source_exists = "source path is '%s'" %\
             os.path.join(tmpdir, dconstants.CONTAINER_SHARE_SOURCE_SUBDIR)
     assert any([container_uri_re.search(l.getMessage()) for l in caplog.records()])
     assert source_exists in [l.getMessage() for l in caplog.records()]
+
+    # make sure that double source (i.e. source/source) is not created
+    source_path_is_re = re.compile(r"source path is '.*/source/source'")
+    assert not any([source_path_is_re.search(l.getMessage()) for l in caplog.records()])
 
 
 @with_all_sources


### PR DESCRIPTION
I believe this regression was introduced with e4480c587f86f59ca5bfa2de7d605fe636155f5b (but it was the right way to do stuff, so I'm just fixing the code around to adapt it to the correct behaviour).