### PR TITLE
dock-pulp plugin

### DIFF
--- a/dock/cli/secret.py
+++ b/dock/cli/secret.py
@@ -1,0 +1,72 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import json
+import argparse
+import logging
+import pkg_resources
+from base64 import b64encode
+
+
+def generate_json(args):
+    with open(args.cert, "r") as fpcer:
+        with open(args.key, "r") as fpkey:
+            pulpsecret = {
+                'apiVersion': 'v1beta3',
+                'kind': 'Secret',
+                'metadata': {
+                    'name': args.name,
+                    'namespace': args.namespace
+                },
+                'data': {
+                    'pulp.cer': b64encode(fpcer.read()),
+                    'pulp.key': b64encode(fpkey.read())
+        }
+    }
+    print(json.dumps(pulpsecret, indent=2))
+
+
+class CLI(object):
+    def __init__(self):
+        self.parser = argparse.ArgumentParser(
+            description="pulpsecret-gen, tool for creating secret resource"
+        )
+
+    def set_arguments(self):
+        try:
+            version = pkg_resources.get_distribution("dock").version
+        except pkg_resources.DistributionNotFound:
+            version = "GIT"
+
+        exclusive_group = self.parser.add_mutually_exclusive_group()
+        exclusive_group.add_argument("-V", "--version", action="version", version=version)
+        self.parser.add_argument('-C', '--cert', default=False, required=True,
+                                 help='specify a certificate file')
+        self.parser.add_argument('-K', '--key', default=False, required=True,
+                                 help='specify a key file')
+        self.parser.add_argument('--name', default='pulpsecret',
+                                 help='resource name')
+        self.parser.add_argument('--namespace', default='default',
+                                 help='namespace')
+
+    def run(self):
+        self.set_arguments()
+        args = self.parser.parse_args()
+        try:
+            generate_json(args)
+        except KeyboardInterrupt:
+            pass
+
+
+def run():
+    cli = CLI()
+    cli.run()
+
+
+if __name__ == '__main__':
+    run()

--- a/dock/cli/secret.py
+++ b/dock/cli/secret.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 import json
 import argparse
-import logging
 import pkg_resources
 from base64 import b64encode
 

--- a/dock/plugins/post_push_to_pulp.py
+++ b/dock/plugins/post_push_to_pulp.py
@@ -40,8 +40,7 @@ class PulpUploader(object):
         # Sanity-check image
         metadata = dockpulp.imgutils.get_metadata(self.filename)
         vers = dockpulp.imgutils.get_versions(metadata)
-        good = True
-        for id, version in vers.items():
+        for _, version in vers.items():
             verparts = version.split('.')
             major = int(verparts[0])
             if major < 1:
@@ -151,11 +150,11 @@ class PulpPushPlugin(PostBuildPlugin):
         with NamedTemporaryFile(prefix='docker-image-',
                                 suffix='.tar.gz') as targz:
             # Compress the tarball docker gave us.
-            self.log.info("Compressing tarball to %s" % targz.name)
+            self.log.info("Compressing tarball to %s", targz.name)
             compress(targz.name, image_stream)
 
             # Find out how to tag this image.
-            self.log.info("Image names: %s" % repr(image_names))
+            self.log.info("Image names: %s", repr(image_names))
 
             # Give that compressed tarball to pulp.
             uploader = PulpUploader(self.pulp_registry_name, targz.name, self.log,
@@ -168,11 +167,11 @@ class PulpPushPlugin(PostBuildPlugin):
         # Add in additional image names, if any
         if self.image_names:
             self.log.info("extending image names")
-            image_names += map(lambda x: ImageName.parse(x), self.image_names)
+            image_names += [ImageName.parse(x) for x in self.image_names]
 
         # Work out image ID
         image = self.workflow.image
-        self.log.info("Image ID: %s" % image)
+        self.log.info("Image ID: %s", image)
 
         if self.load_squashed_image:
             with open(self.workflow.exported_squashed_image.get("path"), "r") as image_stream:

--- a/dock/plugins/prepub_squash.py
+++ b/dock/plugins/prepub_squash.py
@@ -105,8 +105,9 @@ class PrePublishSquashPlugin(PrePublishPlugin):
                    tag=self.tag, output_path=self.workflow.exported_squashed_image.get("path")).run()
             self._get_tarball_metadata()
         else:
+            # squash the image and load it back to engine
             new_id = Squash(log=self.log, image=self.image, from_layer=self.from_layer,
                             tag=self.tag).run()
-        self.workflow.builder.image_id = new_id
+            self.workflow.builder.image_id = new_id
         if self.remove_former_image:
             self.tasker.remove_image(self.image)

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,9 @@ setup(
     url=HOMEPAGE,
     license="BSD",
     entry_points={
-        'console_scripts': ['dock=dock.cli.main:run'],
-        },
+        'console_scripts': ['dock=dock.cli.main:run',
+                            'pulpsecret-gen=dock.cli.secret:run'],
+    },
     packages=find_packages(exclude=["tests", "tests.plugins"]),
     install_requires=_install_requirements(),
     data_files=data_files.items(),


### PR DESCRIPTION
This is a post plugin for using pulp via dockpulp.

Parameters:
 * `pulp_registry_name` (name of registry as configured in `/etc/dockpulp.conf`
 * `load_squashed_image`: load the squashed image directly; use with the squash plugin with `dontload` set to True
 * `image_names`: list of additional ImageName instances to use for tagging
 * `pulp_secret_path`: path to use instead of `$SOURCE_SECRET_PATH` to find `pulp.cer` and `pulp.key`
 * `username`, `password`: auth to use instead of certifcate and key
