### PR TITLE
Add Dockerfile that builds buildroot image with current dock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM fedora:latest
+# e2fsprogs -- docker @ F20 wants it
+RUN yum -y install docker-io git python-docker-py python-setuptools GitPython e2fsprogs koji python-pip
+RUN mkdir /tmp/dock
+ADD . /tmp/dock
+RUN cd /tmp/dock && python setup.py install
+CMD ["dock", "--verbose", "inside-build", "--input", "path"]


### PR DESCRIPTION
There are two usecases for this Dockerfile:
- quick testing of local changes -> easy to build Docker image without creating tarball
- automatic builds of dock's buildroot at Dockerhub