### PR TITLE
post_push_to_pulp: return full image names ready for 'docker pull'

### DIFF
--- a/dock/plugins/post_push_to_pulp.py
+++ b/dock/plugins/post_push_to_pulp.py
@@ -106,6 +106,11 @@ class PulpUploader(object):
         self.log.info("Releasing to crane")
         p.crane()
 
+        # Return the set of qualified repo names for this image
+        return [ImageName(registry=p.registry, repo=repo, tag=tag)
+                for repo, tags in repos_tags_mapping.items()
+                for tag in tags]
+
 
 def compress(filename, ifp):
     _chunk_size = 1024*1024  # 1Mb buffer for writing file
@@ -160,7 +165,7 @@ class PulpPushPlugin(PostBuildPlugin):
             uploader = PulpUploader(self.pulp_registry_name, targz.name, self.log,
                                     pulp_secret_path=self.pulp_secret_path, username=self.username,
                                     password=self.password)
-            uploader.push_tarball_to_pulp(image_names)
+            return uploader.push_tarball_to_pulp(image_names)
 
     def run(self):
         image_names = self.workflow.tag_conf.images[:]
@@ -175,7 +180,10 @@ class PulpPushPlugin(PostBuildPlugin):
 
         if self.load_squashed_image:
             with open(self.workflow.exported_squashed_image.get("path"), "r") as image_stream:
-                self.push_tar(image_stream, image_names)
+                crane_repos = self.push_tar(image_stream, image_names)
         else:
             with self.tasker.d.get_image(image) as image_stream:
-                self.push_tar(image_stream, image_names)
+                crane_repos = self.push_tar(image_stream, image_names)
+
+        self.log.info("Image now available at %s", crane_repos)
+        return crane_repos

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -50,6 +50,7 @@ def test_pulp(tmpdir):
 
     # Mock dockpulp and docker
     dockpulp.Pulp = flexmock(dockpulp.Pulp)
+    dockpulp.Pulp.registry='registry.example.com'
     (flexmock(dockpulp.imgutils).should_receive('get_metadata')
      .with_args(object)
      .and_return([{'id': 'foo'}]))


### PR DESCRIPTION
With the registry configured in dockpulp.conf, this changes the pulp plugin to return a list of full image names including registry, such as:

```
Image now available at [ImageName(image=u'registry.example.com/image-name1:1.0_1'), ImageName(image=u'registry.example.com/image-name2:1.0')]
```
