### PR TITLE
Store crane registry API in the push configuration.

### DIFF
--- a/dock/inner.py
+++ b/dock/inner.py
@@ -138,6 +138,12 @@ class PushConf(object):
         for registry_uri in registry_uris:
             self.add_docker_registry(registry_uri, insecure=insecure)
 
+    def add_pulp_registry(self, name, crane_uri):
+        if crane_uri is None:
+            raise RuntimeError("registry URI cannot be None")
+        r = PulpRegistry(name, crane_uri)
+        self._registries["pulp"].append(r)
+
     @property
     def has_some_docker_registry(self):
         return len(self.docker_registries) > 0

--- a/dock/plugins/input_osv3.py
+++ b/dock/plugins/input_osv3.py
@@ -55,7 +55,7 @@ class OSv3InputPlugin(InputPlugin):
                 'provider_params': {'git_commit': git_ref}
             },
             'image': image,
-            'target_registries': [target_registry] if target_registry is not None else None,
+            'target_registries': [target_registry] if target_registry else None,
             'target_registries_insecure': True,  # FIXME: create plugin for this
             'parent_registry': source_registry,
             'parent_registry_insecure': source_registry_insecure,

--- a/dock/plugins/post_push_to_pulp.py
+++ b/dock/plugins/post_push_to_pulp.py
@@ -19,6 +19,7 @@ import dockpulp.imgutils
 
 import gzip
 import os
+import re
 from tempfile import NamedTemporaryFile
 
 
@@ -108,11 +109,17 @@ class PulpUploader(object):
         p.crane()
 
         # Store the registry URI in the push configuration
+
+        # We only want the hostname[:port]
+        pulp_registry = re.sub(r'^https?://([^/]*)/?.*',
+                               lambda m: m.groups()[0],
+                               p.registry)
+
         self.workflow.push_conf.add_pulp_registry(self.pulp_instance,
-                                                  p.registry)
+                                                  pulp_registry)
 
         # Return the set of qualified repo names for this image
-        return [ImageName(registry=p.registry, repo=repo, tag=tag)
+        return [ImageName(registry=pulp_registry, repo=repo, tag=tag)
                 for repo, tags in repos_tags_mapping.items()
                 for tag in tags]
 

--- a/dock/plugins/post_push_to_pulp.py
+++ b/dock/plugins/post_push_to_pulp.py
@@ -26,8 +26,9 @@ class PulpUploader(object):
     CER = 'pulp.cer'
     KEY = 'pulp.key'
 
-    def __init__(self, pulp_instance, filename, log, pulp_secret_path=None, username=None,
+    def __init__(self, workflow, pulp_instance, filename, log, pulp_secret_path=None, username=None,
                  password=None):
+        self.workflow = workflow
         self.pulp_instance = pulp_instance
         self.filename = filename
         self.pulp_secret_path = pulp_secret_path
@@ -106,6 +107,10 @@ class PulpUploader(object):
         self.log.info("Releasing to crane")
         p.crane()
 
+        # Store the registry URI in the push configuration
+        self.workflow.push_conf.add_pulp_registry(self.pulp_instance,
+                                                  p.registry)
+
         # Return the set of qualified repo names for this image
         return [ImageName(registry=p.registry, repo=repo, tag=tag)
                 for repo, tags in repos_tags_mapping.items()
@@ -162,7 +167,7 @@ class PulpPushPlugin(PostBuildPlugin):
             self.log.info("Image names: %s", repr(image_names))
 
             # Give that compressed tarball to pulp.
-            uploader = PulpUploader(self.pulp_registry_name, targz.name, self.log,
+            uploader = PulpUploader(self.workflow, self.pulp_registry_name, targz.name, self.log,
                                     pulp_secret_path=self.pulp_secret_path, username=self.username,
                                     password=self.password)
             return uploader.push_tarball_to_pulp(image_names)


### PR DESCRIPTION
This ensures it gets stored in the osv3 metadata.

Untested (having trouble testing).