### PR TITLE
Revert previous spec change (02a409e7b4) and fix the code.

### DIFF
--- a/dock.spec
+++ b/dock.spec
@@ -66,7 +66,6 @@ Plugin for submitting metada to OSBS
 Summary:        Python 2 Dock library
 Group:          Development/Tools
 License:        BSD
-BuildRequires:  python-docker-py
 Requires:       python-docker-py
 Requires:       python-requests
 Requires:       python-setuptools
@@ -84,7 +83,6 @@ you started hooking docker into your infrastructure.
 Summary:        Python 3 Dock library
 Group:          Development/Tools
 License:        BSD
-BuildRequires:  python3-docker-py
 Requires:       python3-docker-py
 Requires:       python3-requests
 Requires:       python3-setuptools

--- a/dock/__init__.py
+++ b/dock/__init__.py
@@ -11,9 +11,6 @@ constants
 
 import logging
 
-from dock.api import *
-
-
 def set_logging(name="dock", level=logging.DEBUG):
     # create logger
     logger = logging.getLogger(name)

--- a/dock/cli/main.py
+++ b/dock/cli/main.py
@@ -13,8 +13,8 @@ import os
 import sys
 import pkg_resources
 
-from dock import build_image_here, build_image_in_privileged_container, \
-    build_image_using_hosts_docker, set_logging
+from dock import set_logging
+from dock.api import build_image_here, build_image_in_privileged_container, build_image_using_hosts_docker
 from dock.constants import CONTAINER_BUILD_JSON_PATH, CONTAINER_RESULTS_JSON_PATH, DESCRIPTION, PROG
 from dock.buildimage import BuildImageBuilder
 from dock.inner import BuildResultsEncoder, build_inside, BuildResults


### PR DESCRIPTION
It means that it won't be possible to do
`from dock import build_image_here` but only `from dock.api import build_image_here`, but `docs/api.md` also says to do `from dock.api import ...`