### PR TITLE
Nicer logging of pulp image names

### DIFF
--- a/dock/plugins/post_push_to_pulp.py
+++ b/dock/plugins/post_push_to_pulp.py
@@ -180,7 +180,8 @@ class PulpPushPlugin(PostBuildPlugin):
             compress(targz.name, image_stream)
 
             # Find out how to tag this image.
-            self.log.info("Image names: %s", repr(image_names))
+            self.log.info("Image names: %s", [str(image_name)
+                                              for image_name in image_names])
 
             # Give that compressed tarball to pulp.
             uploader = PulpUploader(self.workflow, self.pulp_registry_name, targz.name, self.log,
@@ -205,5 +206,7 @@ class PulpPushPlugin(PostBuildPlugin):
             with self.tasker.d.get_image(image) as image_stream:
                 crane_repos = self.push_tar(image_stream, image_names)
 
-        self.log.info("Image now available at %s", crane_repos)
+        for image_name in crane_repos:
+            self.log.info("Image available at %s", str(image_name))
+
         return crane_repos


### PR DESCRIPTION
Use str() instead of repr() for logging ImageName objects.

Now logs are a little easier to read with no loss of detail:
```
Image names: ['nmspc/myrepo:origin-20150611152705', 'docker-hello-world:1.0_1', 'docker-hello-world:1.0', 'docker-hello-world:latest']
...
Image available at registry.example.com:5001/docker-hello-world:1.0_1
Image available at registry.example.com:5001/docker-hello-world:1.0
Image available at registry.example.com:5001/docker-hello-world:latest
Image available at registry.example.com:5001/nmspc/myrepo:origin-20150611152705
```