### PR TITLE
Allow using ImageName as dict key in Python 3

### DIFF
--- a/dock/util.py
+++ b/dock/util.py
@@ -94,6 +94,9 @@ class ImageName(object):
     def __eq__(self, other):
         return type(self) == type(other) and self.__dict__ == other.__dict__
 
+    def __hash__(self):
+        return hash(self.to_str())
+
     def copy(self):
         return ImageName(
             registry=self.registry,


### PR DESCRIPTION
I'd like to use this in https://github.com/bkabrda/atomicapp-builder. Thanks.